### PR TITLE
chore: SHA-pin the k6-ci shared workflow

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@main
+    uses: grafana/k6-ci/.github/workflows/all.yml@143ec80c1678ae96a54b82389ea862d4748c27e1 # v0.3.0

--- a/module.go
+++ b/module.go
@@ -45,5 +45,5 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // Exports implements the [modules.Instance] interface and returns the exports
 // of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{Named: map[string]interface{}{}}
+	return modules.Exports{Named: map[string]any{}}
 }


### PR DESCRIPTION
Replaces the floating `@main` reference with the SHA of `v0.3.0`, with the
tag retained as a trailing comment so Renovate can maintain it.